### PR TITLE
Adding `combine` algebra on the `Decider`, `View` and `Saga`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ version = "0.3.1"
 dependencies = [
  "async-trait",
  "derive_more",
+ "serde",
  "tokio",
 ]
 
@@ -182,6 +183,26 @@ name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = "0.1.74"
+serde = {version = "1.0.193", features = ["derive"]}
+
 
 [dev-dependencies]
 derive_more = "0.99.17"

--- a/src/decider_combined.rs
+++ b/src/decider_combined.rs
@@ -1,0 +1,119 @@
+use crate::decider::Decider;
+use crate::{Sum, Sum3};
+
+/// Combine two deciders into one bigger decider
+/// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` and `C2`, `S2`, `E2` into a new decider of type `Sum<C, C2>`, `(S, S2)`, `Sum<E, E2>`
+pub fn combine<'a, C1, S1: Clone, E1, C2, S2: Clone, E2>(
+    decider1: &'a Decider<'a, C1, S1, E1>,
+    decider2: &'a Decider<'a, C2, S2, E2>,
+) -> Decider<'a, Sum<C1, C2>, (S1, S2), Sum<E1, E2>> {
+    let new_decide = Box::new(move |c: &Sum<C1, C2>, s: &(S1, S2)| match c {
+        Sum::First(c) => {
+            let s1 = &s.0;
+            let events = (decider1.decide)(c, s1);
+            events
+                .into_iter()
+                .map(|e: E1| Sum::First(e))
+                .collect::<Vec<Sum<E1, E2>>>()
+        }
+        Sum::Second(c) => {
+            let s2 = &s.1;
+            let events = (decider2.decide)(c, s2);
+            events
+                .into_iter()
+                .map(|e: E2| Sum::Second(e))
+                .collect::<Vec<Sum<E1, E2>>>()
+        }
+    });
+
+    let new_evolve = Box::new(move |s: &(S1, S2), e: &Sum<E1, E2>| match e {
+        Sum::First(e) => {
+            let s1 = &s.0;
+            let new_state = (decider1.evolve)(s1, e);
+            (new_state, s.1.to_owned())
+        }
+        Sum::Second(e) => {
+            let s2 = &s.1;
+            let new_state = (decider2.evolve)(s2, e);
+            (s.0.to_owned(), new_state)
+        }
+    });
+
+    let new_initial_state = Box::new(move || {
+        let s1 = (decider1.initial_state)();
+        let s2 = (decider2.initial_state)();
+        (s1, s2)
+    });
+
+    Decider {
+        decide: new_decide,
+        evolve: new_evolve,
+        initial_state: new_initial_state,
+    }
+}
+
+/// Combine three deciders into one bigger decider
+/// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` ,  `C2`, `S2`, `E2`, and `C3`, `S3`, `E3` into a new decider of type `Sum3<C, C2, C3>`, `(S, S2, S3)`, `Sum3<E, E2, E3>`
+pub fn combine3<'a, C1, S1: Clone, E1, C2, S2: Clone, E2, C3, S3: Clone, E3>(
+    decider1: &'a Decider<'a, C1, S1, E1>,
+    decider2: &'a Decider<'a, C2, S2, E2>,
+    decider3: &'a Decider<'a, C3, S3, E3>,
+) -> Decider<'a, Sum3<C1, C2, C3>, (S1, S2, S3), Sum3<E1, E2, E3>> {
+    let new_decide = Box::new(move |c: &Sum3<C1, C2, C3>, s: &(S1, S2, S3)| match c {
+        Sum3::First(c) => {
+            let s1 = &s.0;
+            let events = (decider1.decide)(c, s1);
+            events
+                .into_iter()
+                .map(|e: E1| Sum3::First(e))
+                .collect::<Vec<Sum3<E1, E2, E3>>>()
+        }
+        Sum3::Second(c) => {
+            let s2 = &s.1;
+            let events = (decider2.decide)(c, s2);
+            events
+                .into_iter()
+                .map(|e: E2| Sum3::Second(e))
+                .collect::<Vec<Sum3<E1, E2, E3>>>()
+        }
+        Sum3::Third(c) => {
+            let s3 = &s.2;
+            let events = (decider3.decide)(c, s3);
+            events
+                .into_iter()
+                .map(|e: E3| Sum3::Third(e))
+                .collect::<Vec<Sum3<E1, E2, E3>>>()
+        }
+    });
+
+    let new_evolve = Box::new(move |s: &(S1, S2, S3), e: &Sum3<E1, E2, E3>| match e {
+        Sum3::First(e) => {
+            let s1 = &s.0;
+            let new_state = (decider1.evolve)(s1, e);
+            (new_state, s.1.to_owned(), s.2.to_owned())
+        }
+        Sum3::Second(e) => {
+            let s2 = &s.1;
+            let new_state = (decider2.evolve)(s2, e);
+            (s.0.to_owned(), new_state, s.2.to_owned())
+        }
+        Sum3::Third(e) => {
+            let s3 = &s.2;
+            let new_state = (decider3.evolve)(s3, e);
+            (s.0.to_owned(), s.1.to_owned(), new_state)
+        }
+    });
+
+    let new_initial_state = Box::new(move || {
+        let s1 = (decider1.initial_state)();
+        let s2 = (decider2.initial_state)();
+        let s3 = (decider3.initial_state)();
+        (s1, s2, s3)
+    });
+
+    Decider {
+        decide: new_decide,
+        evolve: new_evolve,
+        initial_state: new_initial_state,
+    }
+}

--- a/src/decider_combined.rs
+++ b/src/decider_combined.rs
@@ -4,8 +4,8 @@ use crate::{Sum, Sum3};
 /// Combine two deciders into one bigger decider
 /// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` and `C2`, `S2`, `E2` into a new decider of type `Sum<C, C2>`, `(S, S2)`, `Sum<E, E2>`
 pub fn combine<'a, C1, S1: Clone, E1, C2, S2: Clone, E2>(
-    decider1: &'a Decider<'a, C1, S1, E1>,
-    decider2: &'a Decider<'a, C2, S2, E2>,
+    decider1: Decider<'a, C1, S1, E1>,
+    decider2: Decider<'a, C2, S2, E2>,
 ) -> Decider<'a, Sum<C1, C2>, (S1, S2), Sum<E1, E2>> {
     let new_decide = Box::new(move |c: &Sum<C1, C2>, s: &(S1, S2)| match c {
         Sum::First(c) => {
@@ -56,9 +56,9 @@ pub fn combine<'a, C1, S1: Clone, E1, C2, S2: Clone, E2>(
 /// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` ,  `C2`, `S2`, `E2`, and `C3`, `S3`, `E3` into a new decider of type `Sum3<C, C2, C3>`, `(S, S2, S3)`, `Sum3<E, E2, E3>`
 #[allow(clippy::type_complexity)]
 pub fn combine3<'a, C1, S1: Clone, E1, C2, S2: Clone, E2, C3, S3: Clone, E3>(
-    decider1: &'a Decider<'a, C1, S1, E1>,
-    decider2: &'a Decider<'a, C2, S2, E2>,
-    decider3: &'a Decider<'a, C3, S3, E3>,
+    decider1: Decider<'a, C1, S1, E1>,
+    decider2: Decider<'a, C2, S2, E2>,
+    decider3: Decider<'a, C3, S3, E3>,
 ) -> Decider<'a, Sum3<C1, C2, C3>, (S1, S2, S3), Sum3<E1, E2, E3>> {
     let new_decide = Box::new(move |c: &Sum3<C1, C2, C3>, s: &(S1, S2, S3)| match c {
         Sum3::First(c) => {

--- a/src/decider_combined.rs
+++ b/src/decider_combined.rs
@@ -54,6 +54,7 @@ pub fn combine<'a, C1, S1: Clone, E1, C2, S2: Clone, E2>(
 
 /// Combine three deciders into one bigger decider
 /// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` ,  `C2`, `S2`, `E2`, and `C3`, `S3`, `E3` into a new decider of type `Sum3<C, C2, C3>`, `(S, S2, S3)`, `Sum3<E, E2, E3>`
+#[allow(clippy::type_complexity)]
 pub fn combine3<'a, C1, S1: Clone, E1, C2, S2: Clone, E2, C3, S3: Clone, E3>(
     decider1: &'a Decider<'a, C1, S1, E1>,
     decider2: &'a Decider<'a, C2, S2, E2>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,8 @@
 //! ---
 //! Created with `love` by [Fraktalio](https://!fraktalio.com/)
 
+use serde::{Deserialize, Serialize};
+
 /// Aggregate module - belongs to the `Application` layer - composes pure logic and effects (fetching, storing)
 pub mod aggregate;
 /// Decider module - belongs to the `Domain` layer - pure decision making component - pure logic
@@ -331,7 +333,7 @@ pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
 pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;
 
 /// Define the generic Combined/Sum Enum
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Sum<A, B> {
     /// First variant
     First(A),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ pub mod aggregate;
 /// Decider module - belongs to the `Domain` layer - pure decision making component - pure logic
 pub mod decider;
 /// Additional functions on the Decider
-mod decider_combined;
+pub mod decider_combined;
 /// Materialized View module - belongs to the `Application` layer - composes pure event handling algorithm and effects (fetching, storing)
 pub mod materialized_view;
 /// Saga module - belongs to the `Domain` layer - pure mapper of action results/events into new actions/commands
@@ -331,6 +331,7 @@ pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
 pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;
 
 /// Define the generic Combined/Sum Enum
+#[derive(Debug, PartialEq, Clone)]
 pub enum Sum<A, B> {
     /// First variant
     First(A),
@@ -339,6 +340,7 @@ pub enum Sum<A, B> {
 }
 
 /// Define the generic Combined/Sum Enum
+#[derive(Debug, PartialEq, Clone)]
 pub enum Sum3<A, B, C> {
     /// First variant
     First(A),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,8 @@
 pub mod aggregate;
 /// Decider module - belongs to the `Domain` layer - pure decision making component - pure logic
 pub mod decider;
+/// Additional functions on the Decider
+mod decider_combined;
 /// Materialized View module - belongs to the `Application` layer - composes pure event handling algorithm and effects (fetching, storing)
 pub mod materialized_view;
 /// Saga module - belongs to the `Domain` layer - pure mapper of action results/events into new actions/commands
@@ -327,3 +329,21 @@ pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a + Send + Sync>;
 pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
 /// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
 pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;
+
+/// Define the generic Combined/Sum Enum
+pub enum Sum<A, B> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+}
+
+/// Define the generic Combined/Sum Enum
+pub enum Sum3<A, B, C> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+    /// Third variant
+    Third(C),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,16 +312,20 @@ use serde::{Deserialize, Serialize};
 pub mod aggregate;
 /// Decider module - belongs to the `Domain` layer - pure decision making component - pure logic
 pub mod decider;
-/// Additional functions on the Decider
+/// Additional functions on the Decider - combine multiple deciders into one - belongs to the `Domain` layer
 pub mod decider_combined;
 /// Materialized View module - belongs to the `Application` layer - composes pure event handling algorithm and effects (fetching, storing)
 pub mod materialized_view;
 /// Saga module - belongs to the `Domain` layer - pure mapper of action results/events into new actions/commands
 pub mod saga;
+/// Additional functions on the Saga - combine multiple sagas into one - belongs to the `Domain` layer
+pub mod saga_combined;
 /// Saga Manager module - belongs to the `Application` layer - composes pure saga and effects (publishing)
 pub mod saga_manager;
 /// View module - belongs to the `Domain` layer - pure event handling algorithm
 pub mod view;
+/// Additional functions on the View - combine multiple views into one - belongs to the `Domain` layer
+pub mod view_combined;
 
 /// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
 pub type DecideFunction<'a, C, S, E> = Box<dyn Fn(&C, &S) -> Vec<E> + 'a + Send + Sync>;

--- a/src/saga_combined.rs
+++ b/src/saga_combined.rs
@@ -4,8 +4,8 @@ use crate::{Sum, Sum3};
 /// Combine two sagas into one.
 /// Creates a new instance of a Saga by combining two sagas of type `AR1`, `A1` and `AR2`, `A2` into a new saga of type `Sum<AR1, AR2>`, `Sum<A1, A2>`
 pub fn combine<'a, AR1, A1, AR2, A2>(
-    saga1: &'a Saga<'a, AR1, A1>,
-    saga2: &'a Saga<'a, AR2, A2>,
+    saga1: Saga<'a, AR1, A1>,
+    saga2: Saga<'a, AR2, A2>,
 ) -> Saga<'a, Sum<AR1, AR2>, Sum<A1, A2>> {
     let new_react = Box::new(move |ar: &Sum<AR1, AR2>| match ar {
         Sum::First(ar1) => {
@@ -24,9 +24,9 @@ pub fn combine<'a, AR1, A1, AR2, A2>(
 /// Combine three sagas into one.
 /// Creates a new instance of a Saga by combining three sagas of type `AR1`, `A1` ,  `AR2`, `A2`, and `AR3`, `A3` into a new saga of type `Sum3<AR1, AR2, AR3>`, `Sum3<A1, A2, A3>`
 pub fn combine3<'a, AR1, A1, AR2, A2, AR3, A3>(
-    saga1: &'a Saga<'a, AR1, A1>,
-    saga2: &'a Saga<'a, AR2, A2>,
-    saga3: &'a Saga<'a, AR3, A3>,
+    saga1: Saga<'a, AR1, A1>,
+    saga2: Saga<'a, AR2, A2>,
+    saga3: Saga<'a, AR3, A3>,
 ) -> Saga<'a, Sum3<AR1, AR2, AR3>, Sum3<A1, A2, A3>> {
     let new_react = Box::new(move |ar: &Sum3<AR1, AR2, AR3>| match ar {
         Sum3::First(ar1) => {

--- a/src/saga_combined.rs
+++ b/src/saga_combined.rs
@@ -1,0 +1,47 @@
+use crate::saga::Saga;
+use crate::{Sum, Sum3};
+
+/// Combine two sagas into one.
+/// Creates a new instance of a Saga by combining two sagas of type `AR1`, `A1` and `AR2`, `A2` into a new saga of type `Sum<AR1, AR2>`, `Sum<A1, A2>`
+pub fn combine<'a, AR1, A1, AR2, A2>(
+    saga1: &'a Saga<'a, AR1, A1>,
+    saga2: &'a Saga<'a, AR2, A2>,
+) -> Saga<'a, Sum<AR1, AR2>, Sum<A1, A2>> {
+    let new_react = Box::new(move |ar: &Sum<AR1, AR2>| match ar {
+        Sum::First(ar1) => {
+            let a1 = (saga1.react)(ar1);
+            a1.into_iter().map(|a: A1| Sum::First(a)).collect()
+        }
+        Sum::Second(ar2) => {
+            let a2 = (saga2.react)(ar2);
+            a2.into_iter().map(|a: A2| Sum::Second(a)).collect()
+        }
+    });
+
+    Saga { react: new_react }
+}
+
+/// Combine three sagas into one.
+/// Creates a new instance of a Saga by combining three sagas of type `AR1`, `A1` ,  `AR2`, `A2`, and `AR3`, `A3` into a new saga of type `Sum3<AR1, AR2, AR3>`, `Sum3<A1, A2, A3>`
+pub fn combine3<'a, AR1, A1, AR2, A2, AR3, A3>(
+    saga1: &'a Saga<'a, AR1, A1>,
+    saga2: &'a Saga<'a, AR2, A2>,
+    saga3: &'a Saga<'a, AR3, A3>,
+) -> Saga<'a, Sum3<AR1, AR2, AR3>, Sum3<A1, A2, A3>> {
+    let new_react = Box::new(move |ar: &Sum3<AR1, AR2, AR3>| match ar {
+        Sum3::First(ar1) => {
+            let a1 = (saga1.react)(ar1);
+            a1.into_iter().map(|a: A1| Sum3::First(a)).collect()
+        }
+        Sum3::Second(ar2) => {
+            let a2 = (saga2.react)(ar2);
+            a2.into_iter().map(|a: A2| Sum3::Second(a)).collect()
+        }
+        Sum3::Third(ar3) => {
+            let a3 = (saga3.react)(ar3);
+            a3.into_iter().map(|a: A3| Sum3::Third(a)).collect()
+        }
+    });
+
+    Saga { react: new_react }
+}

--- a/src/view_combined.rs
+++ b/src/view_combined.rs
@@ -4,8 +4,8 @@ use crate::{Sum, Sum3};
 /// Combine two views into one.
 /// Creates a new instance of a View by combining two views of type `S1`, `E1` and `S2`, `E2` into a new view of type `(S1, S2)`, `Sum<E1, E2>`
 pub fn combine<'a, S1: Clone, E1, S2: Clone, E2>(
-    view1: &'a View<'a, S1, E1>,
-    view2: &'a View<'a, S2, E2>,
+    view1: View<'a, S1, E1>,
+    view2: View<'a, S2, E2>,
 ) -> View<'a, (S1, S2), Sum<E1, E2>> {
     let new_evolve = Box::new(move |s: &(S1, S2), e: &Sum<E1, E2>| match e {
         Sum::First(e) => {
@@ -35,9 +35,9 @@ pub fn combine<'a, S1: Clone, E1, S2: Clone, E2>(
 /// Combine three views into one.
 /// Creates a new instance of a View by combining three views of type `S1`, `E1` ,  `S2`, `E2`, and `S3`, `E3` into a new view of type `(S1, S2, S3)`, `Sum3<E1, E2, E3>`
 pub fn combine3<'a, S1: Clone, E1, S2: Clone, E2, S3: Clone, E3>(
-    view1: &'a View<'a, S1, E1>,
-    view2: &'a View<'a, S2, E2>,
-    view3: &'a View<'a, S3, E3>,
+    view1: View<'a, S1, E1>,
+    view2: View<'a, S2, E2>,
+    view3: View<'a, S3, E3>,
 ) -> View<'a, (S1, S2, S3), Sum3<E1, E2, E3>> {
     let new_evolve = Box::new(move |s: &(S1, S2, S3), e: &Sum3<E1, E2, E3>| match e {
         Sum3::First(e) => {

--- a/src/view_combined.rs
+++ b/src/view_combined.rs
@@ -1,0 +1,71 @@
+use crate::view::View;
+use crate::{Sum, Sum3};
+
+/// Combine two views into one.
+/// Creates a new instance of a View by combining two views of type `S1`, `E1` and `S2`, `E2` into a new view of type `(S1, S2)`, `Sum<E1, E2>`
+pub fn combine<'a, S1: Clone, E1, S2: Clone, E2>(
+    view1: &'a View<'a, S1, E1>,
+    view2: &'a View<'a, S2, E2>,
+) -> View<'a, (S1, S2), Sum<E1, E2>> {
+    let new_evolve = Box::new(move |s: &(S1, S2), e: &Sum<E1, E2>| match e {
+        Sum::First(e) => {
+            let s1 = &s.0;
+            let new_state = (view1.evolve)(s1, e);
+            (new_state, s.1.to_owned())
+        }
+        Sum::Second(e) => {
+            let s2 = &s.1;
+            let new_state = (view2.evolve)(s2, e);
+            (s.0.to_owned(), new_state)
+        }
+    });
+
+    let new_initial_state = Box::new(move || {
+        let s1 = (view1.initial_state)();
+        let s2 = (view2.initial_state)();
+        (s1, s2)
+    });
+
+    View {
+        evolve: new_evolve,
+        initial_state: new_initial_state,
+    }
+}
+
+/// Combine three views into one.
+/// Creates a new instance of a View by combining three views of type `S1`, `E1` ,  `S2`, `E2`, and `S3`, `E3` into a new view of type `(S1, S2, S3)`, `Sum3<E1, E2, E3>`
+pub fn combine3<'a, S1: Clone, E1, S2: Clone, E2, S3: Clone, E3>(
+    view1: &'a View<'a, S1, E1>,
+    view2: &'a View<'a, S2, E2>,
+    view3: &'a View<'a, S3, E3>,
+) -> View<'a, (S1, S2, S3), Sum3<E1, E2, E3>> {
+    let new_evolve = Box::new(move |s: &(S1, S2, S3), e: &Sum3<E1, E2, E3>| match e {
+        Sum3::First(e) => {
+            let s1 = &s.0;
+            let new_state = (view1.evolve)(s1, e);
+            (new_state, s.1.to_owned(), s.2.to_owned())
+        }
+        Sum3::Second(e) => {
+            let s2 = &s.1;
+            let new_state = (view2.evolve)(s2, e);
+            (s.0.to_owned(), new_state, s.2.to_owned())
+        }
+        Sum3::Third(e) => {
+            let s3 = &s.2;
+            let new_state = (view3.evolve)(s3, e);
+            (s.0.to_owned(), s.1.to_owned(), new_state)
+        }
+    });
+
+    let new_initial_state = Box::new(move || {
+        let s1 = (view1.initial_state)();
+        let s2 = (view2.initial_state)();
+        let s3 = (view3.initial_state)();
+        (s1, s2, s3)
+    });
+
+    View {
+        evolve: new_evolve,
+        initial_state: new_initial_state,
+    }
+}

--- a/tests/aggregate_combined_test.rs
+++ b/tests/aggregate_combined_test.rs
@@ -1,0 +1,548 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use async_trait::async_trait;
+use derive_more::Display;
+
+use fmodel_rust::aggregate::{
+    EventRepository, EventSourcedAggregate, StateRepository, StateStoredAggregate,
+};
+use fmodel_rust::decider::Decider;
+use fmodel_rust::decider_combined::combine;
+use fmodel_rust::Sum;
+
+use crate::api::{
+    CancelOrderCommand, CreateOrderCommand, OrderCancelledEvent, OrderCommand, OrderCreatedEvent,
+    OrderEvent, OrderUpdatedEvent, ShipmentCommand, ShipmentCreatedEvent, ShipmentEvent,
+    UpdateOrderCommand,
+};
+
+mod api;
+
+/// Error type for the application/aggregate
+#[derive(Debug, Display)]
+#[allow(dead_code)]
+enum AggregateError {
+    FetchEvents(String),
+    SaveEvents(String),
+    FetchState(String),
+    SaveState(String),
+}
+
+impl Error for AggregateError {}
+
+/// A simple in-memory event repository - infrastructure
+struct InMemoryEventRepository {
+    events: Mutex<Vec<(Sum<OrderEvent, ShipmentEvent>, i32)>>,
+}
+
+impl InMemoryEventRepository {
+    fn new() -> Self {
+        InMemoryEventRepository {
+            events: Mutex::new(vec![]),
+        }
+    }
+}
+
+trait Id {
+    fn id(&self) -> u32;
+}
+
+impl Id for Sum<OrderEvent, ShipmentEvent> {
+    fn id(&self) -> u32 {
+        match self {
+            Sum::First(event) => event.id(),
+            Sum::Second(event) => event.id(),
+        }
+    }
+}
+
+impl Id for Sum<OrderCommand, ShipmentCommand> {
+    fn id(&self) -> u32 {
+        match self {
+            Sum::First(command) => command.id(),
+            Sum::Second(command) => command.id(),
+        }
+    }
+}
+
+impl Id for (OrderState, ShipmentState) {
+    fn id(&self) -> u32 {
+        self.0.order_id
+    }
+}
+/// Implementation of [EventRepository] for [InMemoryEventRepository] - infrastructure
+#[async_trait]
+impl
+    EventRepository<
+        Sum<OrderCommand, ShipmentCommand>,
+        Sum<OrderEvent, ShipmentEvent>,
+        i32,
+        AggregateError,
+    > for InMemoryEventRepository
+{
+    async fn fetch_events(
+        &self,
+        command: &Sum<OrderCommand, ShipmentCommand>,
+    ) -> Result<Vec<(Sum<OrderEvent, ShipmentEvent>, i32)>, AggregateError> {
+        Ok(self
+            .events
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .filter(|(event, _)| event.id() == command.id())
+            .collect())
+    }
+
+    async fn save(
+        &self,
+        events: &[Sum<OrderEvent, ShipmentEvent>],
+        latest_version: &Option<i32>,
+    ) -> Result<Vec<(Sum<OrderEvent, ShipmentEvent>, i32)>, AggregateError> {
+        let mut latest_version = latest_version.to_owned().unwrap_or(-1);
+        let events = events
+            .into_iter()
+            .map(|event| {
+                latest_version += 1;
+                (event.clone(), latest_version)
+            })
+            .collect::<Vec<(Sum<OrderEvent, ShipmentEvent>, i32)>>();
+
+        self.events
+            .lock()
+            .unwrap()
+            .extend_from_slice(&*events.clone());
+        Ok(Vec::from(events))
+    }
+}
+
+struct InMemoryStateRepository {
+    states: Mutex<HashMap<u32, ((OrderState, ShipmentState), i32)>>,
+}
+
+impl InMemoryStateRepository {
+    fn new() -> Self {
+        InMemoryStateRepository {
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+// Implementation of [StateRepository] for [InMemoryOrderStateRepository]
+#[async_trait]
+impl
+    StateRepository<
+        Sum<OrderCommand, ShipmentCommand>,
+        (OrderState, ShipmentState),
+        i32,
+        AggregateError,
+    > for InMemoryStateRepository
+{
+    async fn fetch_state(
+        &self,
+        command: &Sum<OrderCommand, ShipmentCommand>,
+    ) -> Result<Option<((OrderState, ShipmentState), i32)>, AggregateError> {
+        Ok(self.states.lock().unwrap().get(&command.id()).cloned())
+    }
+
+    async fn save(
+        &self,
+        state: &(OrderState, ShipmentState),
+        version: &Option<i32>,
+    ) -> Result<((OrderState, ShipmentState), i32), AggregateError> {
+        let version = version.to_owned().unwrap_or(0);
+        self.states
+            .lock()
+            .unwrap()
+            .insert(state.id(), (state.clone(), version + 1));
+        Ok((state.clone(), version))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct OrderState {
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+    is_cancelled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ShipmentState {
+    shipment_id: u32,
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+}
+
+/// Decider for the Order aggregate - Domain logic
+fn order_decider<'a>() -> Decider<'a, OrderCommand, OrderState, OrderEvent> {
+    Decider {
+        decide: Box::new(|command, state| match command {
+            OrderCommand::Create(create_cmd) => {
+                vec![OrderEvent::Created(OrderCreatedEvent {
+                    order_id: create_cmd.order_id,
+                    customer_name: create_cmd.customer_name.to_owned(),
+                    items: create_cmd.items.to_owned(),
+                })]
+            }
+            OrderCommand::Update(update_cmd) => {
+                if state.order_id == update_cmd.order_id {
+                    vec![OrderEvent::Updated(OrderUpdatedEvent {
+                        order_id: update_cmd.order_id,
+                        updated_items: update_cmd.new_items.to_owned(),
+                    })]
+                } else {
+                    vec![]
+                }
+            }
+            OrderCommand::Cancel(cancel_cmd) => {
+                if state.order_id == cancel_cmd.order_id {
+                    vec![OrderEvent::Cancelled(OrderCancelledEvent {
+                        order_id: cancel_cmd.order_id,
+                    })]
+                } else {
+                    vec![]
+                }
+            }
+        }),
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                OrderEvent::Created(created_event) => {
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+                OrderEvent::Updated(updated_event) => {
+                    new_state.items = updated_event.updated_items.to_owned();
+                }
+                OrderEvent::Cancelled(_) => {
+                    new_state.is_cancelled = true;
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| OrderState {
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+            is_cancelled: false,
+        }),
+    }
+}
+
+/// Decider for the Shipment aggregate - Domain logic
+fn shipment_decider<'a>() -> Decider<'a, ShipmentCommand, ShipmentState, ShipmentEvent> {
+    Decider {
+        decide: Box::new(|command, _state| match command {
+            ShipmentCommand::Create(create_cmd) => {
+                vec![ShipmentEvent::Created(ShipmentCreatedEvent {
+                    shipment_id: create_cmd.shipment_id,
+                    order_id: create_cmd.order_id,
+                    customer_name: create_cmd.customer_name.to_owned(),
+                    items: create_cmd.items.to_owned(),
+                })]
+            }
+        }),
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                ShipmentEvent::Created(created_event) => {
+                    new_state.shipment_id = created_event.shipment_id;
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| ShipmentState {
+            shipment_id: 0,
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+        }),
+    }
+}
+
+#[tokio::test]
+async fn es_test() {
+    let combined_decider = combine(order_decider(), shipment_decider());
+    let repository = InMemoryEventRepository::new();
+    let aggregate = Arc::new(EventSourcedAggregate::new(repository, combined_decider));
+    // Makes a clone of the Arc pointer.
+    // This creates another pointer to the same allocation, increasing the strong reference count.
+    let aggregate2 = Arc::clone(&aggregate);
+
+    // Lets spawn two threads to simulate two concurrent requests
+    let handle1 = thread::spawn(|| async move {
+        let command = Sum::First(OrderCommand::Create(CreateOrderCommand {
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Created(OrderCreatedEvent {
+                    order_id: 1,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                })),
+                0
+            )]
+        );
+        let command = Sum::First(OrderCommand::Update(UpdateOrderCommand {
+            order_id: 1,
+            new_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Updated(OrderUpdatedEvent {
+                    order_id: 1,
+                    updated_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                })),
+                1
+            )]
+        );
+        let command = Sum::First(OrderCommand::Cancel(CancelOrderCommand { order_id: 1 }));
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Cancelled(OrderCancelledEvent { order_id: 1 })),
+                2
+            )]
+        );
+    });
+
+    let handle2 = thread::spawn(|| async move {
+        let command = Sum::First(OrderCommand::Create(CreateOrderCommand {
+            order_id: 2,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Created(OrderCreatedEvent {
+                    order_id: 2,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                })),
+                0
+            )]
+        );
+        let command = Sum::First(OrderCommand::Update(UpdateOrderCommand {
+            order_id: 2,
+            new_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Updated(OrderUpdatedEvent {
+                    order_id: 2,
+                    updated_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                })),
+                1
+            )]
+        );
+        let command = Sum::First(OrderCommand::Cancel(CancelOrderCommand { order_id: 2 }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            [(
+                Sum::First(OrderEvent::Cancelled(OrderCancelledEvent { order_id: 2 })),
+                2
+            )]
+        );
+    });
+
+    handle1.join().unwrap().await;
+    handle2.join().unwrap().await;
+}
+
+#[tokio::test]
+async fn ss_test() {
+    let combined_decider = combine(order_decider(), shipment_decider());
+    let repository = InMemoryStateRepository::new();
+    let aggregate = Arc::new(StateStoredAggregate::new(repository, combined_decider));
+    let aggregate2 = Arc::clone(&aggregate);
+
+    let handle1 = thread::spawn(|| async move {
+        let command = Sum::First(OrderCommand::Create(CreateOrderCommand {
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 1,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                        is_cancelled: false,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                0
+            )
+        );
+        let command = Sum::First(OrderCommand::Update(UpdateOrderCommand {
+            order_id: 1,
+            new_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 1,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                        is_cancelled: false,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                1
+            )
+        );
+        let command = Sum::First(OrderCommand::Cancel(CancelOrderCommand { order_id: 1 }));
+        let result = aggregate.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 1,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                        is_cancelled: true,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                2
+            )
+        );
+    });
+
+    let handle2 = thread::spawn(|| async move {
+        let command = Sum::First(OrderCommand::Create(CreateOrderCommand {
+            order_id: 2,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 2,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                        is_cancelled: false,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                0
+            )
+        );
+        let command = Sum::First(OrderCommand::Update(UpdateOrderCommand {
+            order_id: 2,
+            new_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 2,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                        is_cancelled: false,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                1
+            )
+        );
+        let command = Sum::First(OrderCommand::Cancel(CancelOrderCommand { order_id: 2 }));
+        let result = aggregate2.handle(&command).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                (
+                    OrderState {
+                        order_id: 2,
+                        customer_name: "John Doe".to_string(),
+                        items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                        is_cancelled: true,
+                    },
+                    ShipmentState {
+                        shipment_id: 0,
+                        order_id: 0,
+                        customer_name: "".to_string(),
+                        items: Vec::new(),
+                    }
+                ),
+                2
+            )
+        );
+    });
+
+    handle1.join().unwrap().await;
+    handle2.join().unwrap().await;
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,5 +1,5 @@
 // Order API
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 pub enum OrderCommand {
     Create(CreateOrderCommand),
@@ -7,20 +7,20 @@ pub enum OrderCommand {
     Cancel(CancelOrderCommand),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CreateOrderCommand {
     pub order_id: u32,
     pub customer_name: String,
     pub items: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateOrderCommand {
     pub order_id: u32,
     pub new_items: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CancelOrderCommand {
     pub order_id: u32,
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -36,6 +36,15 @@ impl OrderCommand {
     }
 }
 
+impl ShipmentCommand {
+    #[allow(dead_code)]
+    pub fn id(&self) -> u32 {
+        match self {
+            ShipmentCommand::Create(c) => c.shipment_id.to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 pub enum OrderEvent {
@@ -69,6 +78,14 @@ impl OrderEvent {
             OrderEvent::Created(c) => c.order_id.to_owned(),
             OrderEvent::Updated(c) => c.order_id.to_owned(),
             OrderEvent::Cancelled(c) => c.order_id.to_owned(),
+        }
+    }
+}
+impl ShipmentEvent {
+    #[allow(dead_code)]
+    pub fn id(&self) -> u32 {
+        match self {
+            ShipmentEvent::Created(c) => c.shipment_id.to_owned(),
         }
     }
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,5 +1,5 @@
 // Order API
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum OrderCommand {
     Create(CreateOrderCommand),
@@ -7,20 +7,20 @@ pub enum OrderCommand {
     Cancel(CancelOrderCommand),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CreateOrderCommand {
     pub order_id: u32,
     pub customer_name: String,
     pub items: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpdateOrderCommand {
     pub order_id: u32,
     pub new_items: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CancelOrderCommand {
     pub order_id: u32,
 }
@@ -82,6 +82,19 @@ pub enum ShipmentCommand {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CreateShipmentCommand {
+    pub shipment_id: u32,
+    pub order_id: u32,
+    pub customer_name: String,
+    pub items: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+#[allow(dead_code)]
+pub enum ShipmentEvent {
+    Created(ShipmentCreatedEvent),
+}
+#[derive(Debug, PartialEq, Clone)]
+pub struct ShipmentCreatedEvent {
     pub shipment_id: u32,
     pub order_id: u32,
     pub customer_name: String,

--- a/tests/decider_test.rs
+++ b/tests/decider_test.rs
@@ -1,8 +1,11 @@
 use fmodel_rust::decider::{Decider, EventComputation, StateComputation};
+use fmodel_rust::decider_combined::combine;
+use fmodel_rust::{Sum::First as Order, Sum::Second as Shipment};
 
 use crate::api::{
-    CancelOrderCommand, CreateOrderCommand, OrderCancelledEvent, OrderCommand, OrderCreatedEvent,
-    OrderEvent, OrderUpdatedEvent,
+    CancelOrderCommand, CreateOrderCommand, CreateShipmentCommand, OrderCancelledEvent,
+    OrderCommand, OrderCreatedEvent, OrderEvent, OrderUpdatedEvent, ShipmentCommand,
+    ShipmentCreatedEvent, ShipmentEvent,
 };
 
 mod api;
@@ -15,7 +18,15 @@ struct OrderState {
     is_cancelled: bool,
 }
 
-fn decider<'a>() -> Decider<'a, OrderCommand, OrderState, OrderEvent> {
+#[derive(Debug, Clone, PartialEq)]
+struct ShipmentState {
+    shipment_id: u32,
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+}
+
+fn order_decider<'a>() -> Decider<'a, OrderCommand, OrderState, OrderEvent> {
     Decider {
         decide: Box::new(|command, state| match command {
             OrderCommand::Create(create_cmd) => {
@@ -71,15 +82,58 @@ fn decider<'a>() -> Decider<'a, OrderCommand, OrderState, OrderEvent> {
     }
 }
 
+fn shipment_decider<'a>() -> Decider<'a, ShipmentCommand, ShipmentState, ShipmentEvent> {
+    Decider {
+        decide: Box::new(|command, _state| match command {
+            ShipmentCommand::Create(create_cmd) => {
+                vec![ShipmentEvent::Created(ShipmentCreatedEvent {
+                    shipment_id: create_cmd.shipment_id,
+                    order_id: create_cmd.order_id,
+                    customer_name: create_cmd.customer_name.to_owned(),
+                    items: create_cmd.items.to_owned(),
+                })]
+            }
+        }),
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                ShipmentEvent::Created(created_event) => {
+                    new_state.shipment_id = created_event.shipment_id;
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| ShipmentState {
+            shipment_id: 0,
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+        }),
+    }
+}
+
 #[test]
 fn test() {
-    let decider: Decider<OrderCommand, OrderState, OrderEvent> = decider();
+    let order_decider: Decider<OrderCommand, OrderState, OrderEvent> = order_decider();
+    let shpiment_decider: Decider<ShipmentCommand, ShipmentState, ShipmentEvent> =
+        shipment_decider();
+    let combined_decider = combine(&order_decider, &shpiment_decider);
+
     let create_order_command = OrderCommand::Create(CreateOrderCommand {
         order_id: 1,
         customer_name: "John Doe".to_string(),
         items: vec!["Item 1".to_string(), "Item 2".to_string()],
     });
-    let new_events = decider.compute_new_events(&[], &create_order_command);
+    let create_shipment_command = ShipmentCommand::Create(CreateShipmentCommand {
+        shipment_id: 1,
+        order_id: 1,
+        customer_name: "John Doe".to_string(),
+        items: vec!["Item 1".to_string(), "Item 2".to_string()],
+    });
+    let new_events = order_decider.compute_new_events(&[], &create_order_command);
     assert_eq!(
         new_events,
         [OrderEvent::Created(OrderCreatedEvent {
@@ -88,7 +142,29 @@ fn test() {
             items: vec!["Item 1".to_string(), "Item 2".to_string()],
         })]
     );
-    let new_state = decider.compute_new_state(None, &create_order_command);
+    let new_events2 =
+        combined_decider.compute_new_events(&[], &Order(create_order_command.clone()));
+    assert_eq!(
+        new_events2,
+        [Order(OrderEvent::Created(OrderCreatedEvent {
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }))]
+    );
+    let new_events3 =
+        combined_decider.compute_new_events(&[], &Shipment(create_shipment_command.clone()));
+    assert_eq!(
+        new_events3,
+        [Shipment(ShipmentEvent::Created(ShipmentCreatedEvent {
+            shipment_id: 1,
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }))]
+    );
+
+    let new_state = order_decider.compute_new_state(None, &create_order_command);
     assert_eq!(
         new_state,
         OrderState {
@@ -98,14 +174,33 @@ fn test() {
             is_cancelled: false,
         }
     );
+    let new_state2 =
+        combined_decider.compute_new_state(None, &Shipment(create_shipment_command.clone()));
+    assert_eq!(
+        new_state2,
+        (
+            OrderState {
+                order_id: 0,
+                customer_name: "".to_string(),
+                items: Vec::new(),
+                is_cancelled: false,
+            },
+            ShipmentState {
+                shipment_id: 1,
+                order_id: 1,
+                customer_name: "John Doe".to_string(),
+                items: vec!["Item 1".to_string(), "Item 2".to_string()],
+            }
+        )
+    );
 
     let cancel_command = OrderCommand::Cancel(CancelOrderCommand { order_id: 1 });
-    let new_events = decider.compute_new_events(&new_events, &cancel_command);
+    let new_events = order_decider.compute_new_events(&new_events, &cancel_command);
     assert_eq!(
         new_events,
         [OrderEvent::Cancelled(OrderCancelledEvent { order_id: 1 })]
     );
-    let new_state = decider.compute_new_state(Some(new_state), &cancel_command);
+    let new_state = order_decider.compute_new_state(Some(new_state), &cancel_command);
     assert_eq!(
         new_state,
         OrderState {

--- a/tests/decider_test.rs
+++ b/tests/decider_test.rs
@@ -118,9 +118,10 @@ fn shipment_decider<'a>() -> Decider<'a, ShipmentCommand, ShipmentState, Shipmen
 #[test]
 fn test() {
     let order_decider: Decider<OrderCommand, OrderState, OrderEvent> = order_decider();
-    let shpiment_decider: Decider<ShipmentCommand, ShipmentState, ShipmentEvent> =
+    let order_decider2: Decider<OrderCommand, OrderState, OrderEvent> = crate::order_decider();
+    let shpiment_decider2: Decider<ShipmentCommand, ShipmentState, ShipmentEvent> =
         shipment_decider();
-    let combined_decider = combine(&order_decider, &shpiment_decider);
+    let combined_decider = combine(order_decider2, shpiment_decider2);
 
     let create_order_command = OrderCommand::Create(CreateOrderCommand {
         order_id: 1,

--- a/tests/materialized_view_combined_test.rs
+++ b/tests/materialized_view_combined_test.rs
@@ -1,0 +1,307 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use async_trait::async_trait;
+use derive_more::Display;
+
+use fmodel_rust::materialized_view::{MaterializedView, ViewStateRepository};
+use fmodel_rust::view::View;
+use fmodel_rust::view_combined::combine;
+use fmodel_rust::Sum;
+
+use crate::api::{
+    OrderCancelledEvent, OrderCreatedEvent, OrderEvent, OrderUpdatedEvent, ShipmentEvent,
+};
+
+mod api;
+
+#[derive(Debug, Clone, PartialEq)]
+struct OrderViewState {
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+    is_cancelled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ShipmentViewState {
+    shipment_id: u32,
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+}
+
+fn order_view<'a>() -> View<'a, OrderViewState, OrderEvent> {
+    View {
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                OrderEvent::Created(created_event) => {
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+                OrderEvent::Updated(updated_event) => {
+                    new_state.items = updated_event.updated_items.to_owned();
+                }
+                OrderEvent::Cancelled(_) => {
+                    new_state.is_cancelled = true;
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| OrderViewState {
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+            is_cancelled: false,
+        }),
+    }
+}
+
+fn shipment_view<'a>() -> View<'a, ShipmentViewState, ShipmentEvent> {
+    View {
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                ShipmentEvent::Created(created_event) => {
+                    new_state.shipment_id = created_event.shipment_id;
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| ShipmentViewState {
+            shipment_id: 0,
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+        }),
+    }
+}
+
+/// Error type for the application/materialized view
+#[derive(Debug, Display)]
+#[allow(dead_code)]
+enum MaterializedViewError {
+    FetchState(String),
+    SaveState(String),
+}
+
+impl Error for MaterializedViewError {}
+
+struct InMemoryViewStateRepository {
+    states: Mutex<HashMap<u32, (OrderViewState, ShipmentViewState)>>,
+}
+
+impl InMemoryViewStateRepository {
+    fn new() -> Self {
+        InMemoryViewStateRepository {
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+trait Id {
+    fn id(&self) -> u32;
+}
+
+impl Id for Sum<OrderEvent, ShipmentEvent> {
+    fn id(&self) -> u32 {
+        match self {
+            Sum::First(event) => event.id(),
+            Sum::Second(event) => event.id(),
+        }
+    }
+}
+
+impl Id for (OrderViewState, ShipmentViewState) {
+    fn id(&self) -> u32 {
+        self.0.order_id
+    }
+}
+
+// Implementation of [ViewStateRepository] for [InMemoryViewOrderStateRepository]
+#[async_trait]
+impl
+    ViewStateRepository<
+        Sum<OrderEvent, ShipmentEvent>,
+        (OrderViewState, ShipmentViewState),
+        MaterializedViewError,
+    > for InMemoryViewStateRepository
+{
+    async fn fetch_state(
+        &self,
+        event: &Sum<OrderEvent, ShipmentEvent>,
+    ) -> Result<Option<(OrderViewState, ShipmentViewState)>, MaterializedViewError> {
+        Ok(self.states.lock().unwrap().get(&event.id()).cloned())
+    }
+
+    async fn save(
+        &self,
+        state: &(OrderViewState, ShipmentViewState),
+    ) -> Result<(OrderViewState, ShipmentViewState), MaterializedViewError> {
+        self.states
+            .lock()
+            .unwrap()
+            .insert(state.id(), state.clone());
+        Ok(state.clone())
+    }
+}
+
+#[tokio::test]
+async fn test() {
+    let combined_view = combine(order_view(), shipment_view());
+    let repository = InMemoryViewStateRepository::new();
+    let materialized_view = Arc::new(MaterializedView::new(repository, combined_view));
+    let materialized_view1 = Arc::clone(&materialized_view);
+    let materialized_view2 = Arc::clone(&materialized_view);
+
+    // Lets spawn two threads to simulate two concurrent requests
+    let handle1 = thread::spawn(|| async move {
+        let event = Sum::First(OrderEvent::Created(OrderCreatedEvent {
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+        let result = materialized_view1.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 1,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                    is_cancelled: false,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+        let event = Sum::First(OrderEvent::Updated(OrderUpdatedEvent {
+            order_id: 1,
+            updated_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = materialized_view1.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 1,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                    is_cancelled: false,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+        let event = Sum::First(OrderEvent::Cancelled(OrderCancelledEvent { order_id: 1 }));
+        let result = materialized_view1.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 1,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                    is_cancelled: true,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+    });
+
+    let handle2 = thread::spawn(|| async move {
+        let event = Sum::First(OrderEvent::Created(OrderCreatedEvent {
+            order_id: 2,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }));
+        let result = materialized_view2.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 2,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                    is_cancelled: false,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+        let event = Sum::First(OrderEvent::Updated(OrderUpdatedEvent {
+            order_id: 2,
+            updated_items: vec!["Item 3".to_string(), "Item 4".to_string()],
+        }));
+        let result = materialized_view2.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 2,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                    is_cancelled: false,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+        let event = Sum::First(OrderEvent::Cancelled(OrderCancelledEvent { order_id: 2 }));
+        let result = materialized_view2.handle(&event).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            (
+                OrderViewState {
+                    order_id: 2,
+                    customer_name: "John Doe".to_string(),
+                    items: vec!["Item 3".to_string(), "Item 4".to_string()],
+                    is_cancelled: true,
+                },
+                ShipmentViewState {
+                    shipment_id: 0,
+                    order_id: 0,
+                    customer_name: "".to_string(),
+                    items: Vec::new(),
+                }
+            )
+        );
+    });
+
+    handle1.join().unwrap().await;
+    handle2.join().unwrap().await;
+}

--- a/tests/saga_test.rs
+++ b/tests/saga_test.rs
@@ -1,10 +1,15 @@
 use fmodel_rust::saga::Saga;
+use fmodel_rust::saga_combined::combine;
+use fmodel_rust::Sum;
 
-use crate::api::{CreateShipmentCommand, OrderCreatedEvent, OrderEvent, ShipmentCommand};
+use crate::api::{
+    CreateShipmentCommand, OrderCommand, OrderCreatedEvent, OrderEvent, ShipmentCommand,
+    ShipmentEvent,
+};
 
 mod api;
 
-fn saga<'a>() -> Saga<'a, OrderEvent, ShipmentCommand> {
+fn order_saga<'a>() -> Saga<'a, OrderEvent, ShipmentCommand> {
     Saga {
         react: Box::new(|event| match event {
             OrderEvent::Created(created_event) => {
@@ -25,22 +30,47 @@ fn saga<'a>() -> Saga<'a, OrderEvent, ShipmentCommand> {
     }
 }
 
+fn shipment_saga<'a>() -> Saga<'a, ShipmentEvent, OrderCommand> {
+    Saga {
+        react: Box::new(|event| match event {
+            ShipmentEvent::Created(created_event) => {
+                vec![OrderCommand::Update(api::UpdateOrderCommand {
+                    order_id: created_event.order_id,
+                    new_items: created_event.items.to_owned(),
+                })]
+            }
+        }),
+    }
+}
+
 #[test]
 fn test() {
-    let saga: Saga<OrderEvent, ShipmentCommand> = saga();
+    let order_saga: Saga<OrderEvent, ShipmentCommand> = order_saga();
+    let shipment_saga: Saga<ShipmentEvent, OrderCommand> = shipment_saga();
+    let combined_saga = combine(&order_saga, &shipment_saga);
     let order_created_event = OrderEvent::Created(OrderCreatedEvent {
         order_id: 1,
         customer_name: "John Doe".to_string(),
         items: vec!["Item 1".to_string(), "Item 2".to_string()],
     });
-    let commands = (saga.react)(&order_created_event);
+    let commands = (order_saga.react)(&order_created_event);
     assert_eq!(
         commands,
-        vec![ShipmentCommand::Create(CreateShipmentCommand {
+        [ShipmentCommand::Create(CreateShipmentCommand {
             shipment_id: 1,
             order_id: 1,
             customer_name: "John Doe".to_string(),
             items: vec!["Item 1".to_string(), "Item 2".to_string()],
         })]
+    );
+    let combined_commands = (combined_saga.react)(&Sum::First(order_created_event));
+    assert_eq!(
+        combined_commands,
+        [Sum::First(ShipmentCommand::Create(CreateShipmentCommand {
+            shipment_id: 1,
+            order_id: 1,
+            customer_name: "John Doe".to_string(),
+            items: vec!["Item 1".to_string(), "Item 2".to_string()],
+        }))]
     );
 }

--- a/tests/view_test.rs
+++ b/tests/view_test.rs
@@ -79,8 +79,9 @@ fn shipment_view<'a>() -> View<'a, ShipmentViewState, ShipmentEvent> {
 #[test]
 fn test() {
     let order_view: View<OrderViewState, OrderEvent> = order_view();
+    let order_view2: View<OrderViewState, OrderEvent> = crate::order_view();
     let shipment_view: View<ShipmentViewState, ShipmentEvent> = shipment_view();
-    let combined_view = combine(&order_view, &shipment_view);
+    let combined_view = combine(order_view2, shipment_view);
 
     let order_created_event = OrderEvent::Created(OrderCreatedEvent {
         order_id: 1,

--- a/tests/view_test.rs
+++ b/tests/view_test.rs
@@ -1,6 +1,11 @@
-use fmodel_rust::view::View;
+use fmodel_rust::view::{View, ViewStateComputation};
+use fmodel_rust::view_combined::combine;
+use fmodel_rust::{Sum::First as Order, Sum::Second as Shipment};
 
-use crate::api::{OrderCancelledEvent, OrderCreatedEvent, OrderEvent, OrderUpdatedEvent};
+use crate::api::{
+    OrderCancelledEvent, OrderCreatedEvent, OrderEvent, OrderUpdatedEvent, ShipmentCreatedEvent,
+    ShipmentEvent,
+};
 
 mod api;
 
@@ -12,7 +17,15 @@ struct OrderViewState {
     is_cancelled: bool,
 }
 
-fn view<'a>() -> View<'a, OrderViewState, OrderEvent> {
+#[derive(Debug, Clone, PartialEq)]
+struct ShipmentViewState {
+    shipment_id: u32,
+    order_id: u32,
+    customer_name: String,
+    items: Vec<String>,
+}
+
+fn order_view<'a>() -> View<'a, OrderViewState, OrderEvent> {
     View {
         evolve: Box::new(|state, event| {
             let mut new_state = state.clone();
@@ -40,15 +53,48 @@ fn view<'a>() -> View<'a, OrderViewState, OrderEvent> {
     }
 }
 
+fn shipment_view<'a>() -> View<'a, ShipmentViewState, ShipmentEvent> {
+    View {
+        evolve: Box::new(|state, event| {
+            let mut new_state = state.clone();
+            match event {
+                ShipmentEvent::Created(created_event) => {
+                    new_state.shipment_id = created_event.shipment_id;
+                    new_state.order_id = created_event.order_id;
+                    new_state.customer_name = created_event.customer_name.to_owned();
+                    new_state.items = created_event.items.to_owned();
+                }
+            }
+            new_state
+        }),
+        initial_state: Box::new(|| ShipmentViewState {
+            shipment_id: 0,
+            order_id: 0,
+            customer_name: "".to_string(),
+            items: Vec::new(),
+        }),
+    }
+}
+
 #[test]
 fn test() {
-    let view: View<OrderViewState, OrderEvent> = view();
+    let order_view: View<OrderViewState, OrderEvent> = order_view();
+    let shipment_view: View<ShipmentViewState, ShipmentEvent> = shipment_view();
+    let combined_view = combine(&order_view, &shipment_view);
+
     let order_created_event = OrderEvent::Created(OrderCreatedEvent {
         order_id: 1,
         customer_name: "John Doe".to_string(),
         items: vec!["Item 1".to_string(), "Item 2".to_string()],
     });
-    let new_state = (view.evolve)(&(view.initial_state)(), &order_created_event);
+    let shipment_created_event = ShipmentEvent::Created(ShipmentCreatedEvent {
+        shipment_id: 1,
+        order_id: 1,
+        customer_name: "John Doe".to_string(),
+        items: vec!["Item 1".to_string(), "Item 2".to_string()],
+    });
+
+    let new_state = order_view.compute_new_state(None, &[&order_created_event]);
     assert_eq!(
         new_state,
         OrderViewState {
@@ -57,6 +103,44 @@ fn test() {
             items: vec!["Item 1".to_string(), "Item 2".to_string()],
             is_cancelled: false,
         }
+    );
+    let new_combined_state2 = combined_view.compute_new_state(None, &[&Order(order_created_event)]);
+    assert_eq!(
+        new_combined_state2,
+        (
+            OrderViewState {
+                order_id: 1,
+                customer_name: "John Doe".to_string(),
+                items: vec!["Item 1".to_string(), "Item 2".to_string()],
+                is_cancelled: false,
+            },
+            ShipmentViewState {
+                shipment_id: 0,
+                order_id: 0,
+                customer_name: "".to_string(),
+                items: Vec::new(),
+            }
+        )
+    );
+
+    let new_combined_state3 =
+        combined_view.compute_new_state(None, &[&Shipment(shipment_created_event)]);
+    assert_eq!(
+        new_combined_state3,
+        (
+            OrderViewState {
+                order_id: 0,
+                customer_name: "".to_string(),
+                items: Vec::new(),
+                is_cancelled: false,
+            },
+            ShipmentViewState {
+                shipment_id: 1,
+                order_id: 1,
+                customer_name: "John Doe".to_string(),
+                items: vec!["Item 1".to_string(), "Item 2".to_string()],
+            }
+        )
     );
 
     let order_updated_event = OrderEvent::Updated(OrderUpdatedEvent {
@@ -67,7 +151,7 @@ fn test() {
             "Item 33".to_string(),
         ],
     });
-    let new_state = (view.evolve)(&new_state, &order_updated_event);
+    let new_state = order_view.compute_new_state(Some(new_state), &[&order_updated_event]);
     assert_eq!(
         new_state,
         OrderViewState {
@@ -83,7 +167,7 @@ fn test() {
     );
 
     let order_canceled_event = OrderEvent::Cancelled(OrderCancelledEvent { order_id: 1 });
-    let new_state = (view.evolve)(&new_state, &order_canceled_event);
+    let new_state = order_view.compute_new_state(Some(new_state), &[&order_canceled_event]);
     assert_eq!(
         new_state,
         OrderViewState {


### PR DESCRIPTION
## Decider
```rust
/// Combine two deciders into one bigger decider
/// Creates a new instance of a Decider by combining two deciders of type `C1`, `S1`, `E1` and `C2`, `S2`, `E2` into a new decider of type `Sum<C, C2>`, `(S, S2)`, `Sum<E, E2>`
pub fn combine<'a, C1, S1: Clone, E1, C2, S2: Clone, E2>(
    decider1: Decider<'a, C1, S1, E1>,
    decider2: Decider<'a, C2, S2, E2>,
) -> Decider<'a, Sum<C1, C2>, (S1, S2), Sum<E1, E2>>
```
## View
```rust
/// Combine two views into one.
/// Creates a new instance of a View by combining two views of type `S1`, `E1` and `S2`, `E2` into a new view of type `(S1, S2)`, `Sum<E1, E2>`
pub fn combine<'a, S1: Clone, E1, S2: Clone, E2>(
    view1: View<'a, S1, E1>,
    view2: View<'a, S2, E2>,
) -> View<'a, (S1, S2), Sum<E1, E2>>
```
## Saga
```rust
/// Combine two sagas into one.
/// Creates a new instance of a Saga by combining two sagas of type `AR1`, `A1` and `AR2`, `A2` into a new saga of type `Sum<AR1, AR2>`, `Sum<A1, A2>`
pub fn combine<'a, AR1, A1, AR2, A2>(
    saga1: Saga<'a, AR1, A1>,
    saga2: Saga<'a, AR2, A2>,
) -> Saga<'a, Sum<AR1, AR2>, Sum<A1, A2>>
```

Combined decider/view/saga would allow you to create `single` aggregate/materialized view/saga manager to handle all the commands/events of your system. Could you check the tests?