### PR TITLE
`async fn` in Traits - a new `stable` feature of Rust 1.75

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,18 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        rust: [ stable, nightly ]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: actions-rs/setup-rust@v1
+      - uses: hecrj/setup-rust-action@v2
         with:
-          profile: default
-          toolchain: '1.75.0'
+          rust-version: ${{ matrix.rust }}
+
+      - uses: actions/checkout@v4
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/setup-rust@v1
+        with:
+          profile: default
+          toolchain: '1.75.0'
+
       - name: Build
         run: cargo build --verbose
+
       - name: Run tests
         run: cargo test --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,18 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        rust: [ stable, nightly ]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: actions-rs/setup-rust@v1
+      - uses: hecrj/setup-rust-action@v2
         with:
-          profile: default
-          toolchain: '1.75.0'
+          rust-version: ${{ matrix.rust }}
+
+      - uses: actions/checkout@v4
 
       - name: Publish
         run: cargo publish --token ${CRATES_TOKEN}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/setup-rust@v1
+        with:
+          profile: default
+          toolchain: '1.75.0'
+
       - name: Publish
         run: cargo publish --token ${CRATES_TOKEN}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "async-trait"
-version = "0.1.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +70,6 @@ dependencies = [
 name = "fmodel-rust"
 version = "0.5.1"
 dependencies = [
- "async-trait",
  "derive_more",
  "serde",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "fmodel-rust"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "derive_more",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,9 @@ description = "Accelerate development of compositional, safe, and ergonomic appl
 license = "Apache-2.0"
 
 [dependencies]
-async-trait = "0.1.75"
 serde = {version = "1.0.193", features = ["derive"]}
 
 
 [dev-dependencies]
 derive_more = "0.99.17"
 tokio = { version = "1.35.1", features = ["rt", "rt-multi-thread", "macros"] }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fmodel-rust"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Accelerate development of compositional, safe, and ergonomic applications/information systems by effectively implementing Event Sourcing and CQRS patterns in Rust."
 license = "Apache-2.0"

--- a/tests/aggregate_combined_test.rs
+++ b/tests/aggregate_combined_test.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use async_trait::async_trait;
 use derive_more::Display;
 
 use fmodel_rust::aggregate::{
@@ -75,7 +74,6 @@ impl Id for (OrderState, ShipmentState) {
     }
 }
 /// Implementation of [EventRepository] for [InMemoryEventRepository] - infrastructure
-#[async_trait]
 impl
     EventRepository<
         Sum<OrderCommand, ShipmentCommand>,
@@ -133,7 +131,6 @@ impl InMemoryStateRepository {
 }
 
 // Implementation of [StateRepository] for [InMemoryOrderStateRepository]
-#[async_trait]
 impl
     StateRepository<
         Sum<OrderCommand, ShipmentCommand>,

--- a/tests/aggregate_test.rs
+++ b/tests/aggregate_test.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use async_trait::async_trait;
 use derive_more::Display;
 
 use fmodel_rust::aggregate::{
@@ -44,7 +43,6 @@ impl InMemoryOrderEventRepository {
 }
 
 /// Implementation of [EventRepository] for [InMemoryOrderEventRepository] - infrastructure
-#[async_trait]
 impl EventRepository<OrderCommand, OrderEvent, i32, AggregateError>
     for InMemoryOrderEventRepository
 {
@@ -97,7 +95,6 @@ impl InMemoryOrderStateRepository {
 }
 
 // Implementation of [StateRepository] for [InMemoryOrderStateRepository]
-#[async_trait]
 impl StateRepository<OrderCommand, OrderState, i32, AggregateError>
     for InMemoryOrderStateRepository
 {

--- a/tests/materialized_view_combined_test.rs
+++ b/tests/materialized_view_combined_test.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use async_trait::async_trait;
 use derive_more::Display;
 
 use fmodel_rust::materialized_view::{MaterializedView, ViewStateRepository};
@@ -125,7 +124,6 @@ impl Id for (OrderViewState, ShipmentViewState) {
 }
 
 // Implementation of [ViewStateRepository] for [InMemoryViewOrderStateRepository]
-#[async_trait]
 impl
     ViewStateRepository<
         Sum<OrderEvent, ShipmentEvent>,

--- a/tests/materialized_view_test.rs
+++ b/tests/materialized_view_test.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use async_trait::async_trait;
 use derive_more::Display;
 
 use fmodel_rust::materialized_view::{MaterializedView, ViewStateRepository};
@@ -72,7 +71,6 @@ impl InMemoryViewOrderStateRepository {
 }
 
 // Implementation of [ViewStateRepository] for [InMemoryViewOrderStateRepository]
-#[async_trait]
 impl ViewStateRepository<OrderEvent, OrderViewState, MaterializedViewError>
     for InMemoryViewOrderStateRepository
 {

--- a/tests/saga_manager_combined_test.rs
+++ b/tests/saga_manager_combined_test.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use derive_more::Display;
 use fmodel_rust::saga::Saga;
 use fmodel_rust::saga_manager::{ActionPublisher, SagaManager};
@@ -65,7 +64,6 @@ impl SimpleActionPublisher {
     }
 }
 
-#[async_trait]
 impl ActionPublisher<Sum<ShipmentCommand, OrderCommand>, SagaManagerError>
     for SimpleActionPublisher
 {

--- a/tests/saga_manager_test.rs
+++ b/tests/saga_manager_test.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use derive_more::Display;
 use fmodel_rust::saga::Saga;
 use fmodel_rust::saga_manager::{ActionPublisher, SagaManager};
@@ -48,7 +47,6 @@ impl SimpleActionPublisher {
     }
 }
 
-#[async_trait]
 impl ActionPublisher<ShipmentCommand, SagaManagerError> for SimpleActionPublisher {
     async fn publish(
         &self,


### PR DESCRIPTION
Removed `async-trait` as a dependency.

Rust 1.75.0, includes support for both `-> impl` Trait notation and `async fn` in traits.

Read more about it: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html