### PR TITLE
Decider: decide fn returns Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ construct.
 Abstraction and generalization are often used together. Abstracts are generalized through parameterization to provide
 more excellent utility.
 
-## `Box<dyn Fn(&C, &S) -> Vec<E>>`
+## `Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error>`
 
-`type DecideFunction<'a, C, S, E> = Box<dyn Fn(&C, &S) -> Vec<E> + 'a + Send + Sync>`
+`type DecideFunction<'a, C, S, E> = Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a + Send + Sync>`
 
 On a higher level of abstraction, any information system is responsible for handling the intent (`Command`) and based on
 the current `State`, produce new facts (`Events`):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,33 +223,33 @@
 //!         decide: Box::new(|command, state| match command {
 //!             // Exhaustive pattern matching on the command
 //!             OrderCommand::Create(create_cmd) => {
-//!                 vec![OrderEvent::Created(OrderCreatedEvent {
+//!                 Ok(vec![OrderEvent::Created(OrderCreatedEvent {
 //!                     order_id: create_cmd.order_id,
 //!                     customer_name: create_cmd.customer_name.to_owned(),
 //!                     items: create_cmd.items.to_owned(),
-//!                 })]
+//!                 })])
 //!             }
 //!             OrderCommand::Update(update_cmd) => {
 //!                 // Your validation logic goes here
 //!                 if state.order_id == update_cmd.order_id {
-//!                     vec![OrderEvent::Updated(OrderUpdatedEvent {
+//!                     Ok(vec![OrderEvent::Updated(OrderUpdatedEvent {
 //!                         order_id: update_cmd.order_id,
 //!                         updated_items: update_cmd.new_items.to_owned(),
-//!                     })]
+//!                     })])
 //!                 } else {
 //!                     // In case of validation failure, return empty list of events or error event
-//!                     vec![]
+//!                     Ok(vec![])
 //!                 }
 //!             }
 //!             OrderCommand::Cancel(cancel_cmd) => {
 //!                 // Your validation logic goes here
 //!                 if state.order_id == cancel_cmd.order_id {
-//!                     vec![OrderEvent::Cancelled(OrderCancelledEvent {
+//!                     Ok(vec![OrderEvent::Cancelled(OrderCancelledEvent {
 //!                         order_id: cancel_cmd.order_id,
-//!                     })]
+//!                     })])
 //!                 } else {
 //!                     // In case of validation failure, return empty list of events or error event
-//!                     vec![]
+//!                     Ok(vec![])
 //!                 }
 //!             }
 //!         }),
@@ -323,7 +323,8 @@ pub mod saga_manager;
 pub mod view;
 
 /// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
-pub type DecideFunction<'a, C, S, E> = Box<dyn Fn(&C, &S) -> Vec<E> + 'a + Send + Sync>;
+pub type DecideFunction<'a, C, S, E, Error> =
+    Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a + Send + Sync>;
 /// The [EvolveFunction] function is used to evolve the state based on the current state and the event.
 pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a + Send + Sync>;
 /// The [InitialStateFunction] function is used to produce the initial state.

--- a/src/saga.rs
+++ b/src/saga.rs
@@ -139,7 +139,7 @@ pub trait ActionComputation<AR, A> {
     fn compute_new_actions(&self, event: &AR) -> Vec<A>;
 }
 
-impl<'a, AR, A> ActionComputation<AR, A> for Saga<'a, AR, A> {
+impl<AR, A> ActionComputation<AR, A> for Saga<'_, AR, A> {
     /// Computes new commands/actions based on the event/action_result.
     fn compute_new_actions(&self, event: &AR) -> Vec<A> {
         (self.react)(event).into_iter().collect()

--- a/src/view.rs
+++ b/src/view.rs
@@ -127,7 +127,7 @@ impl<'a, S, E> View<'a, S, E> {
 
     /// Combines two views into one.
     /// Creates a new instance of a View by combining two views of type `S`, `E` and `S2`, `E2` into a new view of type `(S, S2)`, `Sum<E, E2>`
-    pub fn combine<S2: Clone, E2>(self, view2: View<'a, S2, E2>) -> View<'a, (S, S2), Sum<E, E2>>
+    pub fn combine<S2, E2>(self, view2: View<'a, S2, E2>) -> View<'a, (S, S2), Sum<E, E2>>
     where
         S: Clone,
         S2: Clone,
@@ -164,7 +164,7 @@ pub trait ViewStateComputation<E, S> {
     fn compute_new_state(&self, current_state: Option<S>, events: &[&E]) -> S;
 }
 
-impl<'a, S, E> ViewStateComputation<E, S> for View<'a, S, E> {
+impl<S, E> ViewStateComputation<E, S> for View<'_, S, E> {
     /// Computes new state based on the current state and the events.
     fn compute_new_state(&self, current_state: Option<S>, events: &[&E]) -> S {
         let effective_current_state = current_state.unwrap_or_else(|| (self.initial_state)());

--- a/tests/application/mod.rs
+++ b/tests/application/mod.rs
@@ -106,6 +106,7 @@ pub fn sum_to_event(event: &Sum<OrderEvent, ShipmentEvent>) -> Event {
 }
 
 /// A trait to provide a way to get the id of the messages/entities
+#[allow(dead_code)]
 pub trait Id {
     fn id(&self) -> u32;
 }
@@ -148,6 +149,7 @@ impl Id for (OrderViewState, ShipmentViewState) {
 #[derive(Debug, Display)]
 #[allow(dead_code)]
 pub enum AggregateError {
+    DomainError(String),
     FetchEvents(String),
     SaveEvents(String),
     FetchState(String),


### PR DESCRIPTION
Using `Result` encourages explicit handling of errors, making your code more predictable and robust. Unlike exceptions, which can propagate invisibly, `Result` types must be explicitly handled using pattern matching or methods like `unwrap()`. This explicit handling ensures that every possible error is accounted for, which reduces unexpected behaviors and crashes in production.

Decider just got a new generic param `Error` defaulting to Unit (`()`)
```rust
pub struct Decider<'a, C: 'a, S: 'a, E: 'a, Error: 'a = ()> {
    /// The `decide` function is used to decide which events to produce based on the command and the current state.
    pub decide: DecideFunction<'a, C, S, E, Error>,
    /// The `evolve` function is used to evolve the state based on the current state and the event.
    pub evolve: EvolveFunction<'a, S, E>,
    /// The `initial_state` function is used to produce the initial state of the decider.
    pub initial_state: InitialStateFunction<'a, S>,
}
```
With this change, the `decide` function now returns a Result, wrapping the vector of events. Events are modeled as enums (following a sum type relationship), allowing for the representation of domain-specific error events. This design choice means that errors can be returned immediately as an Err variant rather than being expressed as events that need to be stored. It gives more options in handling error scenarios!

THIS IS A BREAKING CHANGE - `Decider.decide` is affected.
