### PR TITLE
Added new `merge`/`combine` function for the View

### DIFF
--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -22,6 +22,15 @@ pub struct OrderViewState {
     pub is_cancelled: bool,
 }
 
+/// A second version of the ViewOrder entity / It represents the Query Model
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderView2State {
+    pub order_id: u32,
+    pub customer_name: String,
+    pub items: Vec<String>,
+    pub is_cancelled: bool,
+}
+
 /// All variants of Order commands
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]


### PR DESCRIPTION
# Key Features of the Solution
The new function `merge` is introduced on the View component. It looks like a `combine` function, but these are different.

The two functions (`combine` and `merge`) explicitly handle different scenarios, which makes the code more readable and reduces potential runtime complexity.

## combine:

Combines two views that operate on different event types (`E` and `E2`) into a new view operating on `Sum<E, E2>`.
This is ideal for cases where you need to handle separate types of events independently.

## merge:

Composes two views that operate on the same event type (`E`) into a new view operating on `E`.
Ensures both views are updated in response to a shared event.