### PR TITLE
combineN and mergeN introduced

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,10 @@
 //! ---
 //! Created with `love` by [Fraktalio](https://!fraktalio.com/)
 
+use decider::Decider;
+use saga::Saga;
 use serde::{Deserialize, Serialize};
+use view::View;
 
 /// Aggregate module - belongs to the `Application` layer - composes pure logic and effects (fetching, storing)
 pub mod aggregate;
@@ -332,7 +335,7 @@ pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
 /// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
 pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;
 
-/// Define the generic Combined/Sum Enum
+/// Generic Combined/Sum Enum of two variants
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Sum<A, B> {
     /// First variant
@@ -340,6 +343,108 @@ pub enum Sum<A, B> {
     /// Second variant
     Second(B),
 }
+
+/// Generic Combined/Sum Enum of three variants
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum Sum3<A, B, C> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+    /// Third variant
+    Third(C),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Generic Combined/Sum Enum of four variants
+pub enum Sum4<A, B, C, D> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+    /// Third variant
+    Third(C),
+    /// Fourth variant
+    Fourth(D),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Generic Combined/Sum Enum of five variants
+pub enum Sum5<A, B, C, D, E> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+    /// Third variant
+    Third(C),
+    /// Fourth variant
+    Fourth(D),
+    /// Fifth variant
+    Fifth(E),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Generic Combined/Sum Enum of six variants
+pub enum Sum6<A, B, C, D, E, F> {
+    /// First variant
+    First(A),
+    /// Second variant
+    Second(B),
+    /// Third variant
+    Third(C),
+    /// Fourth variant
+    Fourth(D),
+    /// Fifth variant
+    Fifth(E),
+    /// Sixth variant
+    Sixth(F),
+}
+
+/// Convenient type alias that represents 3 combined Deciders
+type Decider3<'a, C1, C2, C3, S1, S2, S3, E1, E2, E3, Error> =
+    Decider<'a, Sum3<C1, C2, C3>, (S1, S2, S3), Sum3<E1, E2, E3>, Error>;
+
+/// Convenient type alias that represents 4 combined Deciders
+type Decider4<'a, C1, C2, C3, C4, S1, S2, S3, S4, E1, E2, E3, E4, Error> =
+    Decider<'a, Sum4<C1, C2, C3, C4>, (S1, S2, S3, S4), Sum4<E1, E2, E3, E4>, Error>;
+
+/// Convenient type alias that represents 5 combined Deciders
+type Decider5<'a, C1, C2, C3, C4, C5, S1, S2, S3, S4, S5, E1, E2, E3, E4, E5, Error> =
+    Decider<'a, Sum5<C1, C2, C3, C4, C5>, (S1, S2, S3, S4, S5), Sum5<E1, E2, E3, E4, E5>, Error>;
+
+/// Convenient type alias that represents 6 combined Deciders
+type Decider6<'a, C1, C2, C3, C4, C5, C6, S1, S2, S3, S4, S5, S6, E1, E2, E3, E4, E5, E6, Error> =
+    Decider<
+        'a,
+        Sum6<C1, C2, C3, C4, C5, C6>,
+        (S1, S2, S3, S4, S5, S6),
+        Sum6<E1, E2, E3, E4, E5, E6>,
+        Error,
+    >;
+
+/// Convenient type alias that represents 3 merged Views
+type View3<'a, S1, S2, S3, E> = View<'a, (S1, S2, S3), E>;
+
+/// Convenient type alias that represents 4 merged Deciders
+type View4<'a, S1, S2, S3, S4, E> = View<'a, (S1, S2, S3, S4), E>;
+
+/// Convenient type alias that represents 5 merged Deciders
+type View5<'a, S1, S2, S3, S4, S5, E> = View<'a, (S1, S2, S3, S4, S5), E>;
+
+/// Convenient type alias that represents 6 merged Deciders
+type View6<'a, S1, S2, S3, S4, S5, S6, E> = View<'a, (S1, S2, S3, S4, S5, S6), E>;
+
+/// Convenient type alias that represents 3 merged Sagas
+type Saga3<'a, AR, A1, A2, A3> = Saga<'a, AR, Sum3<A1, A2, A3>>;
+
+/// Convenient type alias that represents 4 merged Sagas
+type Saga4<'a, AR, A1, A2, A3, A4> = Saga<'a, AR, Sum4<A1, A2, A3, A4>>;
+
+/// Convenient type alias that represents 5 merged Sagas
+type Saga5<'a, AR, A1, A2, A3, A4, A5> = Saga<'a, AR, Sum5<A1, A2, A3, A4, A5>>;
+
+/// Convenient type alias that represents 6 merged Sagas
+type Saga6<'a, AR, A1, A2, A3, A4, A5, A6> = Saga<'a, AR, Sum6<A1, A2, A3, A4, A5, A6>>;
 
 /// Identify the state/command/event.
 /// It is used to identify the concept to what the state/command/event belongs to. For example, the `order_id` or `restaurant_id`.

--- a/src/saga.rs
+++ b/src/saga.rs
@@ -1,4 +1,4 @@
-use crate::{ReactFunction, Sum};
+use crate::{ReactFunction, Saga3, Saga4, Saga5, Saga6, Sum, Sum3, Sum4, Sum5, Sum6};
 
 /// [Saga] is a datatype that represents the central point of control, deciding what to execute next (`A`), based on the action result (`AR`).
 /// It has two generic parameters `AR`/Action Result, `A`/Action , representing the type of the values that Saga may contain or use.
@@ -155,6 +155,118 @@ impl<'a, AR, A> Saga<'a, AR, A> {
         });
 
         Saga { react: new_react }
+    }
+
+    /// Merges three sagas into one.
+    pub fn merge3<A2, A3>(
+        self,
+        saga2: Saga<'a, AR, A2>,
+        saga3: Saga<'a, AR, A3>,
+    ) -> Saga3<'a, AR, A, A2, A3>
+    where
+        A: Clone,
+        A2: Clone,
+        A3: Clone,
+    {
+        self.merge(saga2)
+            .merge(saga3)
+            .map_action(&|a: &Sum<A3, Sum<A2, A>>| match a {
+                Sum::First(a) => Sum3::Third(a.clone()),
+                Sum::Second(Sum::First(a)) => Sum3::Second(a.clone()),
+                Sum::Second(Sum::Second(a)) => Sum3::First(a.clone()),
+            })
+    }
+
+    /// Merges four sagas into one.
+    pub fn merge4<A2, A3, A4>(
+        self,
+        saga2: Saga<'a, AR, A2>,
+        saga3: Saga<'a, AR, A3>,
+        saga4: Saga<'a, AR, A4>,
+    ) -> Saga4<'a, AR, A, A2, A3, A4>
+    where
+        A: Clone,
+        A2: Clone,
+        A3: Clone,
+        A4: Clone,
+    {
+        self.merge(saga2)
+            .merge(saga3)
+            .merge(saga4)
+            .map_action(&|a: &Sum<A4, Sum<A3, Sum<A2, A>>>| match a {
+                Sum::First(a) => Sum4::Fourth(a.clone()),
+                Sum::Second(Sum::First(a)) => Sum4::Third(a.clone()),
+                Sum::Second(Sum::Second(Sum::First(a))) => Sum4::Second(a.clone()),
+                Sum::Second(Sum::Second(Sum::Second(a))) => Sum4::First(a.clone()),
+            })
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// Merges five sagas into one.
+    pub fn merge5<A2, A3, A4, A5>(
+        self,
+        saga2: Saga<'a, AR, A2>,
+        saga3: Saga<'a, AR, A3>,
+        saga4: Saga<'a, AR, A4>,
+        saga5: Saga<'a, AR, A5>,
+    ) -> Saga5<'a, AR, A, A2, A3, A4, A5>
+    where
+        A: Clone,
+        A2: Clone,
+        A3: Clone,
+        A4: Clone,
+        A5: Clone,
+    {
+        self.merge(saga2)
+            .merge(saga3)
+            .merge(saga4)
+            .merge(saga5)
+            .map_action(&|a: &Sum<A5, Sum<A4, Sum<A3, Sum<A2, A>>>>| match a {
+                Sum::First(a) => Sum5::Fifth(a.clone()),
+                Sum::Second(Sum::First(a)) => Sum5::Fourth(a.clone()),
+                Sum::Second(Sum::Second(Sum::First(a))) => Sum5::Third(a.clone()),
+                Sum::Second(Sum::Second(Sum::Second(Sum::First(a)))) => Sum5::Second(a.clone()),
+                Sum::Second(Sum::Second(Sum::Second(Sum::Second(a)))) => Sum5::First(a.clone()),
+            })
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// Merges six sagas into one.
+    pub fn merge6<A2, A3, A4, A5, A6>(
+        self,
+        saga2: Saga<'a, AR, A2>,
+        saga3: Saga<'a, AR, A3>,
+        saga4: Saga<'a, AR, A4>,
+        saga5: Saga<'a, AR, A5>,
+        saga6: Saga<'a, AR, A6>,
+    ) -> Saga6<'a, AR, A, A2, A3, A4, A5, A6>
+    where
+        A: Clone,
+        A2: Clone,
+        A3: Clone,
+        A4: Clone,
+        A5: Clone,
+        A6: Clone,
+    {
+        self.merge(saga2)
+            .merge(saga3)
+            .merge(saga4)
+            .merge(saga5)
+            .merge(saga6)
+            .map_action(
+                &|a: &Sum<A6, Sum<A5, Sum<A4, Sum<A3, Sum<A2, A>>>>>| match a {
+                    Sum::First(a) => Sum6::Sixth(a.clone()),
+                    Sum::Second(Sum::First(a)) => Sum6::Fifth(a.clone()),
+                    Sum::Second(Sum::Second(Sum::First(a))) => Sum6::Fourth(a.clone()),
+                    Sum::Second(Sum::Second(Sum::Second(Sum::First(a)))) => Sum6::Third(a.clone()),
+                    Sum::Second(Sum::Second(Sum::Second(Sum::Second(Sum::First(a))))) => {
+                        Sum6::Second(a.clone())
+                    }
+                    Sum::Second(Sum::Second(Sum::Second(Sum::Second(Sum::Second(a))))) => {
+                        Sum6::First(a.clone())
+                    }
+                },
+            )
     }
 }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,4 +1,4 @@
-use crate::{EvolveFunction, InitialStateFunction, Sum};
+use crate::{EvolveFunction, InitialStateFunction, Sum, View3, View4, View5, View6};
 
 /// [View] represents the event handling algorithm, responsible for translating the events into denormalized state, which is more adequate for querying.
 /// It has two generic parameters `S`/State, `E`/Event , representing the type of the values that View may contain or use.
@@ -190,6 +190,134 @@ impl<'a, S, E> View<'a, S, E> {
             evolve: new_evolve,
             initial_state: new_initial_state,
         }
+    }
+
+    /// Merges three views into one.
+    pub fn merge3<S2, S3>(
+        self,
+        view2: View<'a, S2, E>,
+        view3: View<'a, S3, E>,
+    ) -> View3<'a, S, S2, S3, E>
+    where
+        S: Clone,
+        S2: Clone,
+        S3: Clone,
+    {
+        self.merge(view2).merge(view3).map_state(
+            &|s: &(S, S2, S3)| ((s.0.clone(), s.1.clone()), s.2.clone()),
+            &|s: &((S, S2), S3)| (s.0 .0.clone(), s.0 .1.clone(), s.1.clone()),
+        )
+    }
+
+    /// Merges four views into one.
+    pub fn merge4<S2, S3, S4>(
+        self,
+        view2: View<'a, S2, E>,
+        view3: View<'a, S3, E>,
+        view4: View<'a, S4, E>,
+    ) -> View4<'a, S, S2, S3, S4, E>
+    where
+        S: Clone,
+        S2: Clone,
+        S3: Clone,
+        S4: Clone,
+    {
+        self.merge(view2).merge(view3).merge(view4).map_state(
+            &|s: &(S, S2, S3, S4)| (((s.0.clone(), s.1.clone()), s.2.clone()), s.3.clone()),
+            &|s: &(((S, S2), S3), S4)| {
+                (
+                    s.0 .0 .0.clone(),
+                    s.0 .0 .1.clone(),
+                    s.0 .1.clone(),
+                    s.1.clone(),
+                )
+            },
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// Merges five views into one.
+    pub fn merge5<S2, S3, S4, S5>(
+        self,
+        view2: View<'a, S2, E>,
+        view3: View<'a, S3, E>,
+        view4: View<'a, S4, E>,
+        view5: View<'a, S5, E>,
+    ) -> View5<'a, S, S2, S3, S4, S5, E>
+    where
+        S: Clone,
+        S2: Clone,
+        S3: Clone,
+        S4: Clone,
+        S5: Clone,
+    {
+        self.merge(view2)
+            .merge(view3)
+            .merge(view4)
+            .merge(view5)
+            .map_state(
+                &|s: &(S, S2, S3, S4, S5)| {
+                    (
+                        (((s.0.clone(), s.1.clone()), s.2.clone()), s.3.clone()),
+                        s.4.clone(),
+                    )
+                },
+                &|s: &((((S, S2), S3), S4), S5)| {
+                    (
+                        s.0 .0 .0 .0.clone(),
+                        s.0 .0 .0 .1.clone(),
+                        s.0 .0 .1.clone(),
+                        s.0 .1.clone(),
+                        s.1.clone(),
+                    )
+                },
+            )
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// Merges six views into one.
+    pub fn merge6<S2, S3, S4, S5, S6>(
+        self,
+        view2: View<'a, S2, E>,
+        view3: View<'a, S3, E>,
+        view4: View<'a, S4, E>,
+        view5: View<'a, S5, E>,
+        view6: View<'a, S6, E>,
+    ) -> View6<'a, S, S2, S3, S4, S5, S6, E>
+    where
+        S: Clone,
+        S2: Clone,
+        S3: Clone,
+        S4: Clone,
+        S5: Clone,
+        S6: Clone,
+    {
+        self.merge(view2)
+            .merge(view3)
+            .merge(view4)
+            .merge(view5)
+            .merge(view6)
+            .map_state(
+                &|s: &(S, S2, S3, S4, S5, S6)| {
+                    (
+                        (
+                            (((s.0.clone(), s.1.clone()), s.2.clone()), s.3.clone()),
+                            s.4.clone(),
+                        ),
+                        s.5.clone(),
+                    )
+                },
+                &|s: &(((((S, S2), S3), S4), S5), S6)| {
+                    (
+                        s.0 .0 .0 .0 .0.clone(),
+                        s.0 .0 .0 .0 .1.clone(),
+                        s.0 .0 .0 .1.clone(),
+                        s.0 .0 .1.clone(),
+                        s.0 .1.clone(),
+                        s.1.clone(),
+                    )
+                },
+            )
     }
 }
 


### PR DESCRIPTION
Added a `mergeN` and `combineN` functions for more convenient combining/merging of multiple deciders/views/sagas.
It supports up to six (N= 1..6). Notice, how these are derived/composed from `combine`/`merge` and `map` functions and are only shortcuts. You can create more.