### PR TITLE
`not-send-futures` feature propagated to domain components to remove `Send/Sync` bound

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
-      - name: Run tests
+      - name: Run tests (not-send-futures)
         run: cargo test --features not-send-futures --verbose
+
+      - name: Run tests (default)
+        run: cargo test --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,14 +328,31 @@ pub mod specification;
 pub mod view;
 
 /// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
+#[cfg(not(feature = "not-send-futures"))]
 pub type DecideFunction<'a, C, S, E, Error> =
     Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a + Send + Sync>;
 /// The [EvolveFunction] function is used to evolve the state based on the current state and the event.
+#[cfg(not(feature = "not-send-futures"))]
 pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a + Send + Sync>;
 /// The [InitialStateFunction] function is used to produce the initial state.
+#[cfg(not(feature = "not-send-futures"))]
 pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
 /// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
+#[cfg(not(feature = "not-send-futures"))]
 pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;
+
+/// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
+#[cfg(feature = "not-send-futures")]
+pub type DecideFunction<'a, C, S, E, Error> = Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a>;
+/// The [EvolveFunction] function is used to evolve the state based on the current state and the event.
+#[cfg(feature = "not-send-futures")]
+pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a>;
+/// The [InitialStateFunction] function is used to produce the initial state.
+#[cfg(feature = "not-send-futures")]
+pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a>;
+/// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
+#[cfg(feature = "not-send-futures")]
+pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a>;
 
 /// Generic Combined/Sum Enum of two variants
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/tests/aggregate_combined_test.rs
+++ b/tests/aggregate_combined_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "not-send-futures"))]
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;

--- a/tests/aggregate_test.rs
+++ b/tests/aggregate_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "not-send-futures"))]
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 

--- a/tests/materialized_view_merged_test.rs
+++ b/tests/materialized_view_merged_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "not-send-futures"))]
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/tests/materialized_view_test.rs
+++ b/tests/materialized_view_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "not-send-futures"))]
+
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::thread;

--- a/tests/saga_manager_test.rs
+++ b/tests/saga_manager_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "not-send-futures"))]
+
 use std::sync::Arc;
 use std::thread;
 


### PR DESCRIPTION
Once enabled, the `not-send-futures` will also remove `Send/Sync` bounds from deep Domain components.

Compare the signatures in fmodel:

```rust
/// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
#[cfg(not(feature = "not-send-futures"))]
pub type DecideFunction<'a, C, S, E, Error> =
    Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a + Send + Sync>;
/// The [EvolveFunction] function is used to evolve the state based on the current state and the event.
#[cfg(not(feature = "not-send-futures"))]
pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a + Send + Sync>;
/// The [InitialStateFunction] function is used to produce the initial state.
#[cfg(not(feature = "not-send-futures"))]
pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a + Send + Sync>;
/// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
#[cfg(not(feature = "not-send-futures"))]
pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a + Send + Sync>;

/// The [DecideFunction] function is used to decide which events to produce based on the command and the current state.
#[cfg(feature = "not-send-futures")]
pub type DecideFunction<'a, C, S, E, Error> = Box<dyn Fn(&C, &S) -> Result<Vec<E>, Error> + 'a>;
/// The [EvolveFunction] function is used to evolve the state based on the current state and the event.
#[cfg(feature = "not-send-futures")]
pub type EvolveFunction<'a, S, E> = Box<dyn Fn(&S, &E) -> S + 'a>;
/// The [InitialStateFunction] function is used to produce the initial state.
#[cfg(feature = "not-send-futures")]
pub type InitialStateFunction<'a, S> = Box<dyn Fn() -> S + 'a>;
/// The [ReactFunction] function is used to decide what actions/A to execute next based on the action result/AR.
#[cfg(feature = "not-send-futures")]
pub type ReactFunction<'a, AR, A> = Box<dyn Fn(&AR) -> Vec<A> + 'a>;
```